### PR TITLE
update docs links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ site/
 /dist/
 *.log
 node_modules
+.vscode/
 
 # Ignore npm/yarn debug log
 npm-debug.log

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -14,7 +14,7 @@ To deploy with Helm and Kubernetes role-based access control, or rbac, use the f
 
 ### Bootstrap Local Kubernetes-Helm Dev
 
-- Install [Helm](helm.sh) **Client Version 2.9.1**
+- Install [Helm](https://helm.sh) **Client Version 2.9.1**
     ```
     brew install kubernetes-helm
     ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,8 +22,8 @@ Trickster is a fully-featured HTTP reverse proxy cache for HTTP applications suc
 * Built-in Prometheus [metrics](./metrics.md) and customizable [Health Check](./health.md) Endpoints for end-to-end monitoring
 * [Negative Caching](./negative-caching.md) to prevent domino effect outages
 * High-performance [Collapsed Forwarding](./collapsed-forwarding.md)
-* Best-in-class [Byte Range Request caching and acceleration](./docs/range_request.md).
-* [Distributed Tracing](./docs/tracing.md) via OpenTelemetry, supporting Jaeger and Zipkin
+* Best-in-class [Byte Range Request caching and acceleration](./range_request.md).
+* [Distributed Tracing](./tracing.md) via OpenTelemetry, supporting Jaeger and Zipkin
 * Rules engine for custom request routing and rewriting
 
 ## Time Series Database Accelerator

--- a/docs/open-telemetry.md
+++ b/docs/open-telemetry.md
@@ -2,7 +2,7 @@
 
 Trickster instruments Distributed Tracing with [OpenTelemetry](http://opentelemetry.io/), which is a currently emergent, comprehensive observability stack that is in Public Beta. We import the [OpenTelemetry golang packages](https://github.com/open-telemetry/opentelemetry-go) to instrument support for tracing.
 
-As OpenTelemetry evolves to support additional exporter formats, we will work to extend Trickster to support those as quickly as possible. We also make a best effort to update our otel package imports to the latest releases, whenever we publish a new Trickster release. You can check the [go.mod](../go.mod) file to see which release of opentelemetry-go we are is using. In this view, to see which version of otel a specific Trickster release imports, use the branch selector dropdown to switch to the tag corresponding to that version of Trickster.
+As OpenTelemetry evolves to support additional exporter formats, we will work to extend Trickster to support those as quickly as possible. We also make a best effort to update our otel package imports to the latest releases, whenever we publish a new Trickster release. You can check the [go.mod](https://github.com/trickstercache/trickster/blob/main/go.mod) file to see which release of opentelemetry-go we are is using. In this view, to see which version of otel a specific Trickster release imports, use the branch selector dropdown to switch to the tag corresponding to that version of Trickster.
 
 ## Supported Tracing Backends
 

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -32,7 +32,7 @@ The `methods` section of a Path Config takes a string array of HTTP Methods that
 
 ## Request Rewriters
 
-You can configure paths send inbound requests through a request rewriter that can modify any aspect of the inbound request (method, url, headers, etc.), before being processed by the path route. This means, when the path route inspects the request, it will have already been modified by the rewriter. Provide a rewriter with the `req_rewriter_name` config. It must map to a named/configured request rewriter (see [request rewriters](./request_rewriters.md) for more info). Note, you can also send requests through a rewriter at the origin level. If both are configured, origin-level rewriters are executed before path rewriters are.
+You can configure paths send inbound requests through a request rewriter that can modify any aspect of the inbound request (method, url, headers, etc.), before being processed by the path route. This means, when the path route inspects the request, it will have already been modified by the rewriter. Provide a rewriter with the `req_rewriter_name` config. It must map to a named/configured request rewriter (see [request rewriters](./request-rewriters.md) for more info). Note, you can also send requests through a rewriter at the origin level. If both are configured, origin-level rewriters are executed before path rewriters are.
 
 ```toml
 

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -4,7 +4,7 @@ The Rule Origin is not really a true Origin; it only routes inbound requests to 
 
 A Rule is a single inspection operation performed against a single component of an inbound request, which determines the Next Origin to send the request to. The Next Origin can also be a rule Origin, so as to route requests through multiple Rules before arriving at a true Origin destination.
 
-A rule can optionally rewrite multiple portions of the request before, during and after rule matching, by using [rewriters](./rewriters.md), which allows for powerful and limitless combinations of request rewriting and routing.
+A rule can optionally rewrite multiple portions of the request before, during and after rule matching, by using [request-rewriters](./request-rewriters.md), which allows for powerful and limitless combinations of request rewriting and routing.
 
 ## Rule Parts
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,5 +55,8 @@ nav:
     - Trickster Roadmap: roadmap.md
     - PromSim Update: promsim.md
     - InfluxDB Support: influxdb.md
+  - ClickHouse: clickhouse.md
+  - Collapsed Forwarding: collapsed-forwarding.md
+  - Health Checks: health.md
 
   # - Reference:


### PR DESCRIPTION
Fixes non-`example.conf` links in #3
